### PR TITLE
Provisional PR with monorepo-wide fixes

### DIFF
--- a/packages/bot/src/Bot.ts
+++ b/packages/bot/src/Bot.ts
@@ -1,17 +1,17 @@
-import events from 'events';
-import path from 'path';
 import cheerio from 'cheerio';
+import events from 'events';
 import fetch from 'node-fetch';
+import path from 'path';
 import process from 'process';
-import { Command } from './interfaces/Command';
-import { PluginFunction } from './interfaces/PluginFunction';
-import { MessageHandler } from './types/CallbackTypes';
-import { Message } from './models/Message';
 import { Client } from './Client';
-import { Config } from './interfaces/Config';
-import { PermissionType } from './interfaces/Permission';
 import { DataSaver } from './DataSaver';
 import { ClientFunction } from './interfaces/ClientFunction';
+import { Command } from './interfaces/Command';
+import { Config } from './interfaces/Config';
+import { PermissionType } from './interfaces/Permission';
+import { PluginFunction } from './interfaces/PluginFunction';
+import { Message } from './models/Message';
+import { MessageHandler } from './types/CallbackTypes';
 
 export class Bot extends events.EventEmitter {
     readonly saveFolder: string;
@@ -237,7 +237,7 @@ export class Bot extends events.EventEmitter {
                 title: title || (selected as string),
             };
         } catch (e) {
-            console.error(e);
+            console.error(e as Error);
             return false;
         }
     }

--- a/packages/bot/src/Client.ts
+++ b/packages/bot/src/Client.ts
@@ -4,36 +4,36 @@ import { Message } from './models/Message';
 export abstract class Client extends events.EventEmitter {
     abstract isMyMessage(msg: Message): boolean;
 
-    abstract async isRoomOwnerId(
+    abstract isRoomOwnerId(
         staticUID: string,
         context: Message
     ): Promise<boolean>;
 
-    abstract async send(
+    abstract send(
         content: string,
         context: Message | string
     ): Promise<any>;
 
-    abstract async hardReply(
+    abstract hardReply(
         content: string,
         context: Message | string
     ): Promise<any>;
 
-    abstract async softReply(
+    abstract softReply(
         content: string,
         context: Message | string
     ): Promise<any>;
 
-    abstract async delete(msg: Message): Promise<void>;
+    abstract delete(msg: Message): Promise<void>;
 
-    abstract async edit(
+    abstract edit(
         content: string,
         context: Message | string
     ): Promise<void>;
 
-    abstract async moveTo(message: Message, to: any): Promise<void>;
+    abstract moveTo(message: Message, to: any): Promise<void>;
 
-    abstract async usernameToId(
+    abstract usernameToId(
         username: string,
         context: Message
     ): Promise<string | undefined>;

--- a/packages/bot/tsconfig.json
+++ b/packages/bot/tsconfig.json
@@ -6,6 +6,7 @@
         "lib": ["ES2020"],
         "strict": true,
         "moduleResolution": "node",
+        "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
         "skipLibCheck": true,
         "declaration": true,

--- a/packages/platforms/discord/tsconfig.json
+++ b/packages/platforms/discord/tsconfig.json
@@ -10,7 +10,14 @@
         "noImplicitAny": true,
         "strict": true,
         "forceConsistentCasingInFileNames": true,
-        "isolatedModules": true
+        "isolatedModules": true,
+        "esModuleInterop": true,
+        "lib": ["es2020"],
+        "baseUrl": ".",
+        "paths": {
+            "@chatbot/bot": ["../../bot/src"],
+            "@chatbot/plugins": ["../../plugins/src"]
+        }
     },
     "include": ["src"],
     "exclude": ["node_modules"]

--- a/packages/platforms/slack/tsconfig.json
+++ b/packages/platforms/slack/tsconfig.json
@@ -8,7 +8,12 @@
         "moduleResolution": "node",
         "esModuleInterop": true,
         "skipLibCheck": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "baseUrl": ".",
+        "paths": {
+            "@chatbot/bot": ["../../bot/src"],
+            "@chatbot/plugins": ["../../plugins/src"]
+        }
     },
     "include": ["src"],
     "exclude": ["node_modules"]

--- a/packages/platforms/so/src/SOClient.ts
+++ b/packages/platforms/so/src/SOClient.ts
@@ -1,11 +1,12 @@
 import { Bot, Client, DataSaver, Message } from '@chatbot/bot';
-import path from 'path';
-import WebSocket from 'ws';
 import cheerio from 'cheerio';
-import nodefetch from 'node-fetch';
-import cookiefetch from 'fetch-cookie/node-fetch';
 import events from 'events';
+import cookiefetch from 'fetch-cookie/node-fetch';
+import nodefetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
+import path from 'path';
 import { CookieJar } from 'tough-cookie';
+import { URL } from "url";
+import WebSocket from 'ws';
 import { ChatEvent } from './enum/ChatEvent';
 import formEncoder from './helpers/formEncoder';
 

--- a/packages/platforms/so/src/helpers/formEncoder.ts
+++ b/packages/platforms/so/src/helpers/formEncoder.ts
@@ -1,3 +1,5 @@
+import { URLSearchParams } from "url";
+
 export default function formEncoder(
     form: Record<string, string | number>
 ): string {

--- a/packages/platforms/so/tsconfig.json
+++ b/packages/platforms/so/tsconfig.json
@@ -12,7 +12,13 @@
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "isolatedModules": true,
-        "typeRoots": ["./node_modules/@types", "./src/types"]
+        "lib": ["es2020"],
+        "typeRoots": ["../../../node_modules/@types", "./src/types"],
+        "baseUrl": ".",
+        "paths": {
+            "@chatbot/bot": ["../../bot/src"],
+            "@chatbot/plugins": ["../../plugins/src"]
+        }
     },
     "include": ["src"],
     "exclude": ["node_modules"]

--- a/packages/plugins/src/plugins/eval.ts
+++ b/packages/plugins/src/plugins/eval.ts
@@ -43,13 +43,12 @@ export const evalPlugin: PluginFunction = (bot) => {
         },
     });
 
-    bot.RegisterHandler((msg, client) => {
+    bot.RegisterHandler(async (msg, client) => {
         const text = bot.htmldecode(
             msg.info.rawContent.replace(/<br>/g, '\n').replace(/<.+>/g, '')
         );
         if (
-            // @ts-ignore FIXME: can RegisterHandler accept async callbacks?
-            bot.permissionCheck(client, bot.commands.eval, msg) &&
+            await bot.permissionCheck(client, bot.commands.eval, msg) &&
             /^(\|\|>|>\|\||!!>) ./.test(text)
         ) {
             const trigger = text.match(/^(\|\|>|>\|\||!!>) ./)![1];

--- a/packages/plugins/src/plugins/eval.ts
+++ b/packages/plugins/src/plugins/eval.ts
@@ -48,6 +48,7 @@ export const evalPlugin: PluginFunction = (bot) => {
             msg.info.rawContent.replace(/<br>/g, '\n').replace(/<.+>/g, '')
         );
         if (
+            // @ts-ignore FIXME: can RegisterHandler accept async callbacks?
             bot.permissionCheck(client, bot.commands.eval, msg) &&
             /^(\|\|>|>\|\||!!>) ./.test(text)
         ) {

--- a/packages/plugins/src/plugins/eval/index.ts
+++ b/packages/plugins/src/plugins/eval/index.ts
@@ -76,15 +76,13 @@ export default function (
                 .compileScriptSync(code_to_run)
                 .runSync(context, { timeout });
         } catch (e) {
-            if (typeof e === "object" && e) {
-                sendData(
-                    false,
-                    JSON.stringify(e.toString()),
-                    JSON.stringify([]),
-                    start,
-                    Date.now()
-                );
-            }
+            sendData(
+                false,
+                JSON.stringify(Object.prototype.toString.call(e)),
+                JSON.stringify([]),
+                start,
+                Date.now()
+            );
         }
     });
 }

--- a/packages/plugins/src/plugins/eval/index.ts
+++ b/packages/plugins/src/plugins/eval/index.ts
@@ -76,13 +76,15 @@ export default function (
                 .compileScriptSync(code_to_run)
                 .runSync(context, { timeout });
         } catch (e) {
-            sendData(
-                false,
-                JSON.stringify(e.toString()),
-                JSON.stringify([]),
-                start,
-                Date.now()
-            );
+            if (typeof e === "object" && e) {
+                sendData(
+                    false,
+                    JSON.stringify(e.toString()),
+                    JSON.stringify([]),
+                    start,
+                    Date.now()
+                );
+            }
         }
     });
 }

--- a/packages/plugins/tsconfig.json
+++ b/packages/plugins/tsconfig.json
@@ -10,7 +10,12 @@
         "skipLibCheck": true,
         "declaration": true,
         "allowJs": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "baseUrl": ".",
+        "paths": {
+            "@chatbot/bot": ["../bot/src"],
+            "@chatbot/plugins": ["../plugins/src"]
+        }
     },
     "include": ["src"],
     "exclude": ["node_modules"]

--- a/packages/scripts/tsconfig.json
+++ b/packages/scripts/tsconfig.json
@@ -10,7 +10,12 @@
         "skipLibCheck": true,
         "declaration": true,
         "allowJs": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "baseUrl": ".",
+        "paths": {
+            "@chatbot/bot": ["../bot/src"],
+            "@chatbot/plugins": ["../plugins/src"]
+        }
     },
     "include": ["src"],
     "exclude": ["node_modules"]


### PR DESCRIPTION
This is a provisional pull request that fixes some of the compilation issues due to TypeScript updates, including:

- `paths` and `baseUrl` fields to relevant tsconfig.json files to ensure the compiler understands `@chatbot/*` imports
- several explicit imports from the `url` (native) and `node-fetch` (package) modules
- one `@ts-ignore`  for `bot.permissionCheck` in an `if` statement as the former returns `Promise<boolean>` (needs further investigation to ensure that `await`ing it does not break existing functionality that ended up relying on the bug
- removal of `abstract async` as `async` is not allowed in `abstract` members
- organized imports (automatic action)
- type guards for the `catch` block as TypeScript made the parameter `unknown` by default in `strict` mode recently, which was a breaking change
- added `lib` fields where necessary in tsconfig.json files to ensure the compiler allows new-ish features (such as `matchAll` on strings)