### PR TITLE
Fixes for the isRoomOwnerId check & backup command

### DIFF
--- a/packages/platforms/so/src/SOClient.ts
+++ b/packages/platforms/so/src/SOClient.ts
@@ -1,16 +1,16 @@
 import { Bot, Client, DataSaver, Message } from '@chatbot/bot';
-import { User } from "@userscripters/stackexchange-api-types";
+import { User } from '@userscripters/stackexchange-api-types';
 import cheerio from 'cheerio';
 import events from 'events';
 import cookiefetch from 'fetch-cookie';
 import nodefetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
 import path from 'path';
 import { CookieJar } from 'tough-cookie';
-import { URL } from "url";
+import { URL } from 'url';
 import WebSocket from 'ws';
 import { ChatEvent } from './enum/ChatEvent';
 import formEncoder from './helpers/formEncoder';
-import { FetchCookieImpl } from "./types/fetch-cookies";
+import { FetchCookieImpl } from './types/fetch-cookies';
 
 export class SOClient extends Client {
     private siteURL: string;
@@ -254,8 +254,10 @@ export class SOClient extends Client {
     }
 
     async isRoomOwnerId(staticUID: string, context: Message): Promise<boolean> {
+        const uid = parseInt(staticUID);
+
         return (await this.getRoomOwners(context.info.contextId)).some(
-            (owner) => owner.id === staticUID
+            (owner) => owner.id === uid
         );
     }
 
@@ -407,7 +409,10 @@ export class SOClient extends Client {
 
     /* Client Specific Methods */
 
-    async stats(id: string, api_site_param = this.api_site_param!): Promise<User | false> {
+    async stats(
+        id: string,
+        api_site_param = this.api_site_param!
+    ): Promise<User | false> {
         const resp = await this.fetch(
             `https://api.stackexchange.com/2.2/users/${id}?site=${api_site_param.trim()}`
         );

--- a/packages/plugins/src/plugins/default/backup.ts
+++ b/packages/plugins/src/plugins/default/backup.ts
@@ -43,7 +43,7 @@ export const backup: PluginFunction = (bot, config) => {
             const { ok, status } = res;
 
             if (!ok) {
-                let errorPfx = 'Failed to backup data.';
+                const errorPfx = 'Failed to backup data.';
 
                 const errorMap: Record<number, string> = {
                     401: ' Please check your GitHub credentials',


### PR DESCRIPTION
This PR fixes a couple of issues with the bot's plugins:

1. `SOClient`'s `isRoomOwnerId` check never matched room owners because `getRoomOwners` returns a list of RO objects with `id` of type `number`, whereas the `staticUID` parameter is of type `string`. It would be better to not parse the ids as numbers, but since the chances of SE, Inc. updating chat are non-existent, it's safer to just convert the parameter to a number.
2. The `backup` command should handle GitHub's API errors to prevent sending a misleading `[Backup](undefined) Created` response (as no Gist is actually created).